### PR TITLE
Added a 9 minute timer to the overworld

### DIFF
--- a/evanescentgame/project.godot
+++ b/evanescentgame/project.godot
@@ -34,7 +34,7 @@ window/stretch/mode="canvas_items"
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/dialogue_manager/plugin.cfg", "res://addons/phantom_camera/plugin.cfg")
+enabled=PackedStringArray("res://addons/dialogue_manager/plugin.cfg")
 
 [input]
 

--- a/evanescentgame/singletons/scene_loader.gd
+++ b/evanescentgame/singletons/scene_loader.gd
@@ -18,7 +18,9 @@ func load_scene(scene_path):
 		ResourceLoader.load_threaded_request(scene_path)
 	
 	# Free the current scene
-	get_tree().current_scene.queue_free()
+	var current_scene = get_tree().current_scene
+	get_tree().current_scene = null
+	current_scene.queue_free()
 	
 	# Begin loading next scene
 	is_loading = true

--- a/evanescentgame/top_level_scenes/overworld/overworld_manager.gd
+++ b/evanescentgame/top_level_scenes/overworld/overworld_manager.gd
@@ -1,9 +1,14 @@
 extends Node
 
+const scene_duration = 540.0 # secs until scene change
 
+func load_underworld():
+	SceneLoader.load_scene("res://top_level_scenes/underworld/underworld.tscn")
+	
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
+	await(get_tree().create_timer(scene_duration).timeout)
+	load_underworld()
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.


### PR DESCRIPTION


# Pull Request Template

## What?
Added a 9-minute timer to the Overworld. When time is up, return the player to the underworld.

---

## Why?
Makes the game loop functionable.

---

## How?
Added a 540 second timer. When time runs out, call a function to send the player back to the underworld. Also includes a fix to scene_loader.gd so that the scene doesn't end when the function is called.

---

# Optional fields (can improve PR readability) 

## Type of Change (choose one)

- [ ] 🐛 Bug fix (addresses a defect)
- [x] ✨ Feature (adds new functionality)
- [ ] 🧹 Chore (refactor, cleanup, documentation, etc.)
- [ ] ⚠️ Breaking change (incompatible with an existing interface)

---

## Points of Emphasis
Highlight any specific areas where you would like focused feedback from reviewers. **Example:** "Please focus feedback on the caching implementation and API response handling."
